### PR TITLE
Add JVC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 Currently supported (i.e. tested) models:
 * MB130 (ProCaster 65UNB815H)
+* (JVC LT-40C890)
 * ... (may work well with other similar models too)
 > Since these TVs are sold under many brands, the model number is quite ambiguous. One way to get a model number is from the title of the service menu (press remote buttons in the following sequence: HOME,4,7,2,5).
 

--- a/nodes/remote-button.js
+++ b/nodes/remote-button.js
@@ -1,18 +1,18 @@
 module.exports = function(RED) {
     function RemoteButtonNode(config) {
         RED.nodes.createNode(this,config);
-        this.button = config.button;        
+        this.button = config.button;
         let node = this;
-        
+
         this.on('input', function(msg, send, done) {
             // For maximum backwards compatibility, check that send exists.
             // If this node is installed in Node-RED 0.x, it will need to
             // fallback to using `node.send`
             send = send || function() { node.send.apply(node,arguments) }
-            
+
             msg.payload = node.button;
             send(msg);
-            
+
             // Once finished, call 'done'.
             // This call is wrapped in a check that 'done' exists
             // so the node will work in earlier versions of Node-RED (<1.0)

--- a/nodes/vestel-config.html
+++ b/nodes/vestel-config.html
@@ -28,6 +28,7 @@
         <select id="node-config-input-selectedTvModel">
             <option value="MB130">Default (MB130)</option>
             <option value="MB130">MB130</option>
+            <option value=""> (JVC LT-40C890)</option>
             <option value="other">other (custom port and path below required!)</option>
         </select>
     </div>

--- a/nodes/vestel-config.js
+++ b/nodes/vestel-config.js
@@ -4,12 +4,12 @@ module.exports = function(RED) {
     function VestelConfigurationNode(n) {
         RED.nodes.createNode(this,n);
         this.name = n.name;
-        
+
         this.tvIpAddress = n.tvIpAddress;
         this.selectedTvModel = n.selectedTvModel;
         this.customPort = n.customPort;
         this.customPath = n.customPath;
-        
+
         const tv_models_library = {
             "MB130": {
                 "keys": keyMaps.keycode_map_vestel,
@@ -26,11 +26,11 @@ module.exports = function(RED) {
             // to the list of models available.
             // (TODO: read the available models there automatically somehow)
         };
-        
+
         this.getTcpPort = this.customPort || tv_models_library[this.selectedTvModel].port;
         this.getPath = this.customPath || tv_models_library[this.selectedTvModel].path;
         this.getKeyMap = tv_models_library[this.selectedTvModel].keys;
-        this.getIpAddress = this.tvIpAddress;        
+        this.getIpAddress = this.tvIpAddress;
     }
 
     RED.nodes.registerType("vestel-config",VestelConfigurationNode);

--- a/nodes/vestel-config.js
+++ b/nodes/vestel-config.js
@@ -16,6 +16,12 @@ module.exports = function(RED) {
                 "path": "/apps/SmartCenter",
                 "port": 56789
                 },
+            // JVC LT-40C890
+            "": {
+                "keys": keyMaps.keycode_map_vestel,
+                "path": "/apps/SmartCenter",
+                "port": 56789
+                },
             "other": {
                 "keys": keyMaps.keycode_map_vestel,
                 "path": "/unknown/path",

--- a/nodes/vestel-remote-control.js
+++ b/nodes/vestel-remote-control.js
@@ -1,13 +1,13 @@
 module.exports = function(RED) {
-    
+
     const http = require('http'); // used for sending the commands to the tv
-    
+
     function VestelControlNode(config) {
         RED.nodes.createNode(this,config);
-        
+
         // Get the config node
         this.configurationNode = RED.nodes.getNode(config.configurationNode);
-        
+
         let node = this;
         this.on('input', function(msg, send, done) {
             let TV = this.configurationNode;
@@ -30,15 +30,15 @@ module.exports = function(RED) {
                     errorMessage = "Remote command not supported: " + requestedButton;
                 }
             }
-            
+
             // Send the HTTP request:
             if (!errorMessage) {
                 node.debug("Sending command: " + keyCodeToBeSent);
-            
+
                 // Node.js http.request:
                 // https://nodejs.org/api/http.html#http_http_request_url_options_callback
                 const postData = "<?xml version='1.0' ?><remote><key code='" +keyCodeToBeSent+ "'/></remote>"
-                
+
                 const options = {
                     hostname: TV.getIpAddress,
                     port: TV.getTcpPort,
@@ -50,19 +50,19 @@ module.exports = function(RED) {
                     'Connection': 'Keep-Alive'
                     }
                 };
-        
-                const req = http.request(options);                
-                
+
+                const req = http.request(options);
+
                 req.on('error', (e) => {
                     errorMessage = `Is the TV listening? (${e.message})`;
                     this.warn(errorMessage);
                     this.status({fill:"red",shape:"ring",text: errorMessage});
                 });
-                
+
                 // Write data to request body
                 req.write(postData);
                 req.end();
-                
+
                 // For maximum backwards compatibility, check that send exists.
                 // If this node is installed in Node-RED 0.x, it will need to
                 // fallback to using `node.send`
@@ -71,7 +71,7 @@ module.exports = function(RED) {
                 msg.payload = postData;
                 send(msg);
             }
-            
+
             // If an error is hit, report it to the runtime
             if (errorMessage) {
                 this.status({fill:"red",shape:"ring",text: errorMessage});

--- a/test/remote-button_spec.js
+++ b/test/remote-button_spec.js
@@ -34,21 +34,21 @@ describe('remote-button Node', function () {
         },
         { id: "__test_helper_node__", type: "helper" }
     ];
-    
+
     helper.load(remotebuttonNode, flow, function () {
       var buttonNode = helper.getNode("n1");
       var testHelperNode = helper.getNode("__test_helper_node__");
-      
+
       testHelperNode.on("input", function (msg) {
         msg.should.have.property('payload', 'SETTINGS_SYSTEM');
         done();
       });
-      
+
       buttonNode.receive({ payload: "something" });
     });
   });
-  
-  
+
+
   it('should output a MUTE button command', function (done) {
 
     var flow = [
@@ -66,16 +66,16 @@ describe('remote-button Node', function () {
         },
         { id: "__test_helper_node__", type: "helper" }
     ];
-    
+
     helper.load(remotebuttonNode, flow, function () {
       var buttonNode = helper.getNode("n1");
       var testHelperNode = helper.getNode("__test_helper_node__");
-      
+
       testHelperNode.on("input", function (msg) {
         msg.should.have.property('payload', 'MUTE');
         done();
       });
-      
+
       buttonNode.receive({ payload: "something" });
     });
   });

--- a/test/vestel-remote-control_spec.js
+++ b/test/vestel-remote-control_spec.js
@@ -23,7 +23,7 @@ describe('vestel-remote-control Node', function () {
   it('should make correct HTTP requests', function (done) {
     //this.timeout(15000);
     //setTimeout(done, 15000);
-    
+
     var flow = [
         {
             "id": "testednode",
@@ -49,9 +49,9 @@ describe('vestel-remote-control Node', function () {
         },
         { id: "__test_helper_node__", type: "helper" }
     ];
-    
+
     helper.load([vestelconfigNode ,vestelremotecontrolNode], flow, function () {
-      
+
       var testHelperNode = helper.getNode("__test_helper_node__");
       i = 0;
       while (testHelperNode == null) {
@@ -61,14 +61,14 @@ describe('vestel-remote-control Node', function () {
             return
           }
       }
-      
+
       var testedNode = helper.getNode("testednode");
-      
+
       testHelperNode.on("input", function (msg) {
         msg.should.have.property('payload', "<?xml version='1.0' ?><remote><key code='1010'/></remote>");
         done();
       });
-      
+
       testedNode.receive({ payload: "BACK" });
     });
   });


### PR DESCRIPTION
I haven't tested the Node module, but the following curl works with a JVC LT-40C890. I'm also unclear how to get the Vestel model of it...:
`curl -H 'Host: <TV IP>:56789' --data '<?xml version='1.0' ?><remote><key code=1016/></remote>' 'http://<TV IP>:56789/apps/SmartCenter'`